### PR TITLE
fix footer image overlapping last item in contributor list

### DIFF
--- a/src/components/organisms/Footer/Footer.tsx
+++ b/src/components/organisms/Footer/Footer.tsx
@@ -27,7 +27,7 @@ const BackgroundWrapper = styled.div`
 `;
 
 const StyledFooter = styled.footer`
-  padding-top: 30px;
+  padding-top: 100px;
 `;
 
 const MobileFlex = styled(Flex)`


### PR DESCRIPTION
The footer image of the rocket was overlapping the last person in the contributor list, causing problems with hovering on desktop and bad spacing on mobile.